### PR TITLE
hide netherlicious campfires without netherlicious

### DIFF
--- a/src/main/java/connor135246/campfirebackport/client/compat/nei/NEIConfig.java
+++ b/src/main/java/connor135246/campfirebackport/client/compat/nei/NEIConfig.java
@@ -4,7 +4,11 @@ import codechicken.nei.api.API;
 import codechicken.nei.api.IConfigureNEI;
 import codechicken.nei.recipe.ICraftingHandler;
 import codechicken.nei.recipe.IUsageHandler;
+import connor135246.campfirebackport.common.blocks.CampfireBackportBlocks;
+import connor135246.campfirebackport.common.compat.CampfireBackportCompat;
+import connor135246.campfirebackport.config.CampfireBackportConfig;
 import connor135246.campfirebackport.util.Reference;
+import net.minecraft.item.ItemStack;
 
 public class NEIConfig implements IConfigureNEI
 {
@@ -24,6 +28,14 @@ public class NEIConfig implements IConfigureNEI
 
         API.registerRecipeHandler((ICraftingHandler) sblocks);
         API.registerUsageHandler((IUsageHandler) sblocks);
+
+        if (!(CampfireBackportCompat.isNetherliciousLoaded || CampfireBackportConfig.showExtraCampfires))
+        {
+            API.hideItem(new ItemStack(CampfireBackportBlocks.foxfire_campfire));
+            API.hideItem(new ItemStack(CampfireBackportBlocks.foxfire_campfire_base));
+            API.hideItem(new ItemStack(CampfireBackportBlocks.shadow_campfire));
+            API.hideItem(new ItemStack(CampfireBackportBlocks.shadow_campfire_base));
+        }
     }
 
     @Override

--- a/src/main/java/connor135246/campfirebackport/common/CommonProxy.java
+++ b/src/main/java/connor135246/campfirebackport/common/CommonProxy.java
@@ -77,7 +77,7 @@ public class CommonProxy
             sendNEIGTNHCatalyst(neiID, "campfirebackport:soul_campfire", 0);
             sendNEIGTNHCatalyst(neiID, "campfirebackport:soul_campfire_base", -1);
 
-            if (CampfireBackportCompat.isNetherliciousLoaded)
+            if (CampfireBackportCompat.isNetherliciousLoaded || CampfireBackportConfig.showExtraCampfires)
             {
                 sendNEIGTNHCatalyst(neiID, "campfirebackport:foxfire_campfire", 0);
                 sendNEIGTNHCatalyst(neiID, "campfirebackport:foxfire_campfire_base", -1);

--- a/src/main/java/connor135246/campfirebackport/common/blocks/BlockCampfire.java
+++ b/src/main/java/connor135246/campfirebackport/common/blocks/BlockCampfire.java
@@ -70,7 +70,8 @@ public class BlockCampfire extends BlockContainer implements ICampfire
         this.setHardness(2.0F);
         this.setResistance(2.0F);
         this.setStepSound(Block.soundTypeWood);
-        this.setCreativeTab(CreativeTabs.tabDecorations);
+        if (!EnumCampfireType.isNetherlicious(typeIndex) || CampfireBackportCompat.isNetherliciousLoaded || CampfireBackportConfig.showExtraCampfires)
+            this.setCreativeTab(CreativeTabs.tabDecorations);
 
         this.lit = lit;
         this.typeIndex = typeIndex;

--- a/src/main/java/connor135246/campfirebackport/config/CampfireBackportConfig.java
+++ b/src/main/java/connor135246/campfirebackport/config/CampfireBackportConfig.java
@@ -57,6 +57,8 @@ public class CampfireBackportConfig
 
     public static boolean renderItem3D;
 
+    public static boolean showExtraCampfires;
+
     public static EnumCampfireType regenCampfires;
     public static int[] regularRegen;
     public static int[] soulRegen;
@@ -223,6 +225,10 @@ public class CampfireBackportConfig
 
         renderItem3D = config.get(Configuration.CATEGORY_GENERAL, ConfigReference.renderItem3D, false,
                 StringParsers.translateTooltip("render_3d")).setLanguageKey(CONFIGPREFIX + "render_3d").getBoolean();
+
+        showExtraCampfires = config.get(Configuration.CATEGORY_GENERAL, ConfigReference.showExtraCampfires, false,
+                StringParsers.translateTooltip("show_extra_campfires")).setLanguageKey(CONFIGPREFIX + "show_extra_campfires").setRequiresMcRestart(true)
+                .getBoolean();
 
         charcoalOnly = config.get(Configuration.CATEGORY_GENERAL, ConfigReference.charcoalOnly, false,
                 StringParsers.translateTooltip("charcoal")).setLanguageKey(CONFIGPREFIX + "charcoal").setRequiresMcRestart(true).getBoolean();
@@ -727,6 +733,8 @@ public class CampfireBackportConfig
 
         charcoalOnly = false;
         soulSoilOnly = false;
+
+        showExtraCampfires = false;
 
         regenCampfires = EnumCampfireType.NEITHER;
         regularRegen = ConfigReference.defaultRegRegen;

--- a/src/main/java/connor135246/campfirebackport/config/ConfigReference.java
+++ b/src/main/java/connor135246/campfirebackport/config/ConfigReference.java
@@ -140,6 +140,7 @@ public class ConfigReference
             soulSoilOnly = "Soul Soil Only",
             soulSoilOnly_OLD = "Soul Soil Only (Netherlicious)",
             renderItem3D = "Render Item in 3D",
+            showExtraCampfires = "Show Extra Campfires",
             regenCampfires = "Regeneration Campfires",
             regularRegen = "Regeneration Settings (Regular Campfires)",
             soulRegen = "Regeneration Settings (Soul Campfires)",
@@ -184,6 +185,7 @@ public class ConfigReference
     static
     {
         configOrder.add(renderItem3D);
+        configOrder.add(showExtraCampfires);
         configOrder.add(charcoalOnly);
         configOrder.add(soulSoilOnly);
         configOrder.add(automation);

--- a/src/main/resources/assets/campfirebackport/lang/en_US.lang
+++ b/src/main/resources/assets/campfirebackport/lang/en_US.lang
@@ -203,6 +203,8 @@ campfirebackport.ignitor=Ignitor
 
 campfirebackport.config.render_3d=Render Item in 3D
 campfirebackport.config.render_3d.tooltip=Client-side option. If true, campfire items in your inventory will render as a 3D block instead of a 2D item.
+campfirebackport.config.show_extra_campfires=Show Extra Campfires
+campfirebackport.config.show_extra_campfires.tooltip=Foxfire and shadow campfires are extra campfire types that are inspired by the Netherlicious mod. They are treated as soul campfires for the purposes of most config options. If you don't have Netherlicious, they will be hidden from NEI. Set this to true to make them show up anyway.
 campfirebackport.config.charcoal=Charcoal Only
 campfirebackport.config.charcoal.tooltip=If true, regular campfires can be crafted only using charcoal. In vanilla either coal or charcoal can be used, but breaking campfires always drops charcoal. If for some reason you don't want players to be able to turn coal into charcoal, turn this on.
 campfirebackport.config.soul_soil=Soul Soil Only


### PR DESCRIPTION
hide netherlicious campfires in NEI and creative menu if you don't have netherlicious. added a config option to control this.